### PR TITLE
fix: 修复 Docker 首次启动数据库未初始化问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/config ./config
 
 # Copy pre-compiled runtime scripts
 COPY --from=builder --chown=nextjs:nodejs /app/dist-scripts ./dist-scripts
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/seed-admin.js ./dist-scripts/scripts/seed-admin.js
 
 # Create data directory for SQLite persistence
 RUN mkdir -p /app/data && chown -R nextjs:nodejs /app/data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,8 @@ SEED_MARKER="/app/data/.seed_completed"
 VERSION_FILE="/app/data/.app_version"
 # Use local Prisma CLI from node_modules
 PRISMA_BIN="node /app/node_modules/prisma/build/index.js"
+SEED_ADMIN_SCRIPT="/app/dist-scripts/scripts/seed-admin.js"
+REBUILD_TAGS_SCRIPT="/app/dist-scripts/scripts/rebuild-system-tags.js"
 
 # Get current app version from package.json
 CURRENT_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "unknown")
@@ -16,7 +18,7 @@ CURRENT_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || ech
 chown -R nextjs:nodejs /app/data /app/config
 
 # Check if the persistent database exists
-if [ ! -f "$TARGET_DB" ]; then
+if [ ! -s "$TARGET_DB" ]; then
     echo "[Entrypoint] Initializing database..."
     if [ -f "$SOURCE_DB" ]; then
         echo "[Entrypoint] Copying pre-packaged database from $SOURCE_DB to $TARGET_DB"
@@ -28,37 +30,41 @@ if [ ! -f "$TARGET_DB" ]; then
         # Record initial version
         echo "$CURRENT_VERSION" > "$VERSION_FILE"
     else
-        echo "[Entrypoint] Warning: Source database not found at $SOURCE_DB. Skipping initialization."
+        echo "[Entrypoint] Source database not found at $SOURCE_DB. Initializing with migrations."
     fi
 else
     echo "[Entrypoint] Database already exists at $TARGET_DB."
-    
-    # Check for version upgrade
-    PREVIOUS_VERSION=""
-    if [ -f "$VERSION_FILE" ]; then
-        PREVIOUS_VERSION=$(cat "$VERSION_FILE")
-    fi
-    
-    # Run migrations to ensure DB schema is up to date with new code version
-    echo "[Entrypoint] Running database migrations to sync schema..."
-    cd /app && $PRISMA_BIN migrate deploy --schema=./prisma/schema.prisma && {
-        echo "[Entrypoint] Migrations completed successfully."
-        
-        # Note: seed is NOT run here because:
-        # - New installs: pre-packaged DB already contains seed data
-        # - Upgrades: admin user already exists, tags are rebuilt by rebuild-system-tags.js
-        
-        # Check if version changed - rebuild system tags automatically
-        if [ "$PREVIOUS_VERSION" != "$CURRENT_VERSION" ]; then
-            echo "[Entrypoint] Version upgrade detected: $PREVIOUS_VERSION -> $CURRENT_VERSION"
-            echo "[Entrypoint] Rebuilding system tags to sync with new version..."
-            cd /app && node ./dist-scripts/scripts/rebuild-system-tags.js && {
-                echo "[Entrypoint] System tags rebuilt successfully."
-            } || echo "[Entrypoint] Tag rebuild failed (non-fatal, continuing...)."
-            # Update version marker
-            echo "$CURRENT_VERSION" > "$VERSION_FILE"
-        fi
-    } || echo "[Entrypoint] Migration failed or no pending migrations."
+fi
+
+# Check for version upgrade
+PREVIOUS_VERSION=""
+if [ -f "$VERSION_FILE" ]; then
+    PREVIOUS_VERSION=$(cat "$VERSION_FILE")
+fi
+
+# Run migrations to ensure DB schema is available and up to date.
+echo "[Entrypoint] Running database migrations to sync schema..."
+cd /app && $PRISMA_BIN migrate deploy --schema=./prisma/schema.prisma && {
+    echo "[Entrypoint] Migrations completed successfully."
+} || echo "[Entrypoint] Migration failed or no pending migrations."
+
+if [ ! -f "$SEED_MARKER" ]; then
+    echo "[Entrypoint] Seeding default admin user..."
+    cd /app && node "$SEED_ADMIN_SCRIPT" && {
+        echo "[Entrypoint] Admin seed completed successfully."
+        touch "$SEED_MARKER"
+    } || echo "[Entrypoint] Admin seed failed (non-fatal, continuing...)."
+fi
+
+# Check if version changed - rebuild system tags automatically
+if [ "$PREVIOUS_VERSION" != "$CURRENT_VERSION" ]; then
+    echo "[Entrypoint] Version upgrade detected: $PREVIOUS_VERSION -> $CURRENT_VERSION"
+    echo "[Entrypoint] Rebuilding system tags to sync with new version..."
+    cd /app && node "$REBUILD_TAGS_SCRIPT" && {
+        echo "[Entrypoint] System tags rebuilt successfully."
+    } || echo "[Entrypoint] Tag rebuild failed (non-fatal, continuing...)."
+    # Update version marker
+    echo "$CURRENT_VERSION" > "$VERSION_FILE"
 fi
 
 # HTTPS Setup

--- a/scripts/seed-admin.js
+++ b/scripts/seed-admin.js
@@ -1,0 +1,71 @@
+const { PrismaClient } = require('@prisma/client');
+const { hash } = require('bcryptjs');
+
+const DEFAULT_ADMIN = {
+    email: 'admin@localhost',
+    password: '123456',
+    name: 'Admin',
+    role: 'admin',
+    isActive: true,
+    educationStage: 'junior_high',
+    enrollmentYear: 2025,
+};
+
+async function seedAdmin({ prisma, hash: hashPassword }) {
+    const existingUser = await prisma.user.findUnique({
+        where: { email: DEFAULT_ADMIN.email },
+    });
+
+    if (existingUser) {
+        await prisma.user.update({
+            where: { email: DEFAULT_ADMIN.email },
+            data: {
+                educationStage: DEFAULT_ADMIN.educationStage,
+                enrollmentYear: DEFAULT_ADMIN.enrollmentYear,
+            },
+        });
+        return { action: 'updated', email: DEFAULT_ADMIN.email };
+    }
+
+    const hashedPassword = await hashPassword(DEFAULT_ADMIN.password, 12);
+
+    await prisma.user.create({
+        data: {
+            email: DEFAULT_ADMIN.email,
+            password: hashedPassword,
+            name: DEFAULT_ADMIN.name,
+            role: DEFAULT_ADMIN.role,
+            isActive: DEFAULT_ADMIN.isActive,
+            educationStage: DEFAULT_ADMIN.educationStage,
+            enrollmentYear: DEFAULT_ADMIN.enrollmentYear,
+        },
+    });
+
+    return { action: 'created', email: DEFAULT_ADMIN.email };
+}
+
+async function main() {
+    const prisma = new PrismaClient();
+
+    try {
+        const result = await seedAdmin({ prisma, hash });
+        if (result.action === 'created') {
+            console.log('Success! Admin user created.');
+            console.log(`Email: ${result.email}`);
+            console.log(`Password: ${DEFAULT_ADMIN.password}`);
+        } else {
+            console.log('Admin user already exists. Updated defaults.');
+        }
+    } finally {
+        await prisma.$disconnect();
+    }
+}
+
+if (require.main === module) {
+    main().catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });
+}
+
+module.exports = { seedAdmin, DEFAULT_ADMIN };

--- a/src/__tests__/unit/docker/seed-admin.test.ts
+++ b/src/__tests__/unit/docker/seed-admin.test.ts
@@ -1,0 +1,63 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+describe('seed-admin docker helper', () => {
+    it('creates the default admin user when it does not exist', async () => {
+        const createdUsers: unknown[] = [];
+        const prisma = {
+            user: {
+                findUnique: vi.fn().mockResolvedValue(null),
+                create: vi.fn().mockImplementation(async ({ data }) => {
+                    createdUsers.push(data);
+                    return { email: data.email };
+                }),
+                update: vi.fn(),
+            },
+        };
+        const hash = vi.fn().mockResolvedValue('hashed-password');
+        const { seedAdmin } = require('../../../../scripts/seed-admin.js');
+
+        const result = await seedAdmin({ prisma, hash });
+
+        expect(result).toEqual({ action: 'created', email: 'admin@localhost' });
+        expect(hash).toHaveBeenCalledWith('123456', 12);
+        expect(prisma.user.create).toHaveBeenCalledWith({
+            data: {
+                email: 'admin@localhost',
+                password: 'hashed-password',
+                name: 'Admin',
+                role: 'admin',
+                isActive: true,
+                educationStage: 'junior_high',
+                enrollmentYear: 2025,
+            },
+        });
+        expect(createdUsers).toHaveLength(1);
+    });
+
+    it('updates default education fields when the admin user already exists', async () => {
+        const prisma = {
+            user: {
+                findUnique: vi.fn().mockResolvedValue({ email: 'admin@localhost' }),
+                create: vi.fn(),
+                update: vi.fn().mockResolvedValue({ email: 'admin@localhost' }),
+            },
+        };
+        const hash = vi.fn();
+        const { seedAdmin } = require('../../../../scripts/seed-admin.js');
+
+        const result = await seedAdmin({ prisma, hash });
+
+        expect(result).toEqual({ action: 'updated', email: 'admin@localhost' });
+        expect(hash).not.toHaveBeenCalled();
+        expect(prisma.user.create).not.toHaveBeenCalled();
+        expect(prisma.user.update).toHaveBeenCalledWith({
+            where: { email: 'admin@localhost' },
+            data: {
+                educationStage: 'junior_high',
+                enrollmentYear: 2025,
+            },
+        });
+    });
+});


### PR DESCRIPTION
## 说明

这个 PR 修复 Docker 镜像首次启动时数据库未初始化的问题。

关联 Issue：#79

当前 Docker 启动脚本依赖 `/app/prisma/dev.db` 作为预置数据库，但实际镜像中该文件不存在。首次启动时会跳过初始化，导致 `/app/data/dev.db` 为空库，登录和注册时出现：

```text
The table `main.User` does not exist in the current database.
```

## 修改内容

- Docker 首次启动时，如果 `/app/data/dev.db` 不存在或为空，仍然执行 `prisma migrate deploy`
- 新增 `scripts/seed-admin.js`，使用生产环境可直接运行的 Node.js 脚本创建默认管理员
- Dockerfile 将 `seed-admin.js` 复制到最终运行镜像中
- `docker-entrypoint.sh` 在缺少 seed marker 时执行管理员初始化
- 增加单元测试覆盖管理员 seed 行为

## 验证

已本地验证：

```bash
npm run test:unit -- src/__tests__/unit/docker/seed-admin.test.ts
```

结果：

```text
Test Files  19 passed (19)
Tests       279 passed (279)
```

同时使用官方镜像挂载修复后的 entrypoint 和 seed 脚本，模拟全新空数据目录启动，验证通过：

- 自动执行 Prisma migrations
- 自动创建 `admin@localhost`
- 自动重建系统标签
- 不再出现 `main.User does not exist`

补充说明：我是项目试用者，不是专业程序员，本次定位和修复主要由 AI 辅助完成。如判断或实现有不妥之处，还请见谅并指正。
